### PR TITLE
General improvements & fixes

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		285B8ED437195E9D9C0B966F934098E0 /* Pods-TipSee_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 730ACFD2C6715FD3F414215C72929B5F /* Pods-TipSee_Tests-dummy.m */; };
 		48079BA504D63CCA5EDEA28AE24B183C /* TipSee-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 190B1FD472F39D6681F963042AB502B6 /* TipSee-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		50AB26B9BB8A5A766F037018662F6071 /* Pods-TipSee_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 626E30C2E78E6D73BC3500BE14D8B7ED /* Pods-TipSee_Example-dummy.m */; };
+		53213060242A8AB500649999 /* TipSeeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5321305E242A8AAA00649999 /* TipSeeManager.swift */; };
 		5366524E240C331300CC1370 /* TipSeeManager+AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5366524D240C331200CC1370 /* TipSeeManager+AttributedText.swift */; };
 		53665256240CF01D00CC1370 /* NSAttributedString+Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53665255240CF01D00CC1370 /* NSAttributedString+Size.swift */; };
 		5366525A240CFB1B00CC1370 /* TipSee+AttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53665259240CFB1B00CC1370 /* TipSee+AttributedText.swift */; };
@@ -18,7 +19,6 @@
 		87BCBA2F2358E135000BCF46 /* TipTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCBA282358E134000BCF46 /* TipTarget.swift */; };
 		87BCBA302358E135000BCF46 /* TipSee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCBA292358E134000BCF46 /* TipSee.swift */; };
 		87BCBA312358E135000BCF46 /* BubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCBA2A2358E134000BCF46 /* BubbleView.swift */; };
-		87BCBA322358E135000BCF46 /* TipSeeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCBA2B2358E134000BCF46 /* TipSeeManager.swift */; };
 		87BCBA332358E135000BCF46 /* TipOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BCBA2C2358E134000BCF46 /* TipOption.swift */; };
 		89CA7B364639908B5801FE89F65F56E7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; platformFilter = ios; };
 		A93C2F45B504FE192CED0C5B091D343B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; platformFilter = ios; };
@@ -59,6 +59,7 @@
 		48D83B29FE53722A324DF93F8718463E /* Pods-TipSee_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-TipSee_Example-Info.plist"; sourceTree = "<group>"; };
 		4FEBDA5BE2516FEA069B949E06CAF672 /* TipSee.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = TipSee.modulemap; sourceTree = "<group>"; };
 		529FA6CF58D776D7EBB25B7510135F37 /* TipSee.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TipSee.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5321305E242A8AAA00649999 /* TipSeeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TipSeeManager.swift; path = TipSee/Classes/TipSeeManager.swift; sourceTree = "<group>"; };
 		5366524D240C331200CC1370 /* TipSeeManager+AttributedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TipSeeManager+AttributedText.swift"; path = "TipSee/Classes/TipSeeManager+AttributedText.swift"; sourceTree = "<group>"; };
 		53665255240CF01D00CC1370 /* NSAttributedString+Size.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSAttributedString+Size.swift"; path = "TipSee/Classes/NSAttributedString+Size.swift"; sourceTree = "<group>"; };
 		53665259240CFB1B00CC1370 /* TipSee+AttributedText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TipSee+AttributedText.swift"; path = "TipSee/Classes/TipSee+AttributedText.swift"; sourceTree = "<group>"; };
@@ -74,7 +75,6 @@
 		87BCBA282358E134000BCF46 /* TipTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TipTarget.swift; path = TipSee/Classes/TipTarget.swift; sourceTree = "<group>"; };
 		87BCBA292358E134000BCF46 /* TipSee.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TipSee.swift; path = TipSee/Classes/TipSee.swift; sourceTree = "<group>"; };
 		87BCBA2A2358E134000BCF46 /* BubbleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BubbleView.swift; path = TipSee/Classes/BubbleView.swift; sourceTree = "<group>"; };
-		87BCBA2B2358E134000BCF46 /* TipSeeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TipSeeManager.swift; path = TipSee/Classes/TipSeeManager.swift; sourceTree = "<group>"; };
 		87BCBA2C2358E134000BCF46 /* TipOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TipOption.swift; path = TipSee/Classes/TipOption.swift; sourceTree = "<group>"; };
 		8C5F090058F39AF409B1B7271DE16DA6 /* Pods-TipSee_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-TipSee_Tests.modulemap"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -202,7 +202,7 @@
 				53665255240CF01D00CC1370 /* NSAttributedString+Size.swift */,
 				87BCBA262358E134000BCF46 /* TipItem.swift */,
 				87BCBA2C2358E134000BCF46 /* TipOption.swift */,
-				87BCBA2B2358E134000BCF46 /* TipSeeManager.swift */,
+				5321305E242A8AAA00649999 /* TipSeeManager.swift */,
 				5366524D240C331200CC1370 /* TipSeeManager+AttributedText.swift */,
 				F82900BE236979FD00FA2182 /* TipSeeManagerProtocol.swift */,
 				87BCBA292358E134000BCF46 /* TipSee.swift */,
@@ -350,7 +350,7 @@
 				LastUpgradeCheck = 1100;
 				TargetAttributes = {
 					B908D34FF2E893C3D472ABE0F48A8FA1 = {
-						LastSwiftMigration = 1110;
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -412,10 +412,10 @@
 				87BCBA312358E135000BCF46 /* BubbleView.swift in Sources */,
 				F82900BC2369792B00FA2182 /* TipSeeConfiguration.swift in Sources */,
 				F82900BF236979FD00FA2182 /* TipSeeManagerProtocol.swift in Sources */,
+				53213060242A8AB500649999 /* TipSeeManager.swift in Sources */,
 				87BCBA2D2358E135000BCF46 /* TipItem.swift in Sources */,
 				87BCBA2F2358E135000BCF46 /* TipTarget.swift in Sources */,
 				AD8BDECC2E0C0E3F2158D45C215704B6 /* TipSee-dummy.m in Sources */,
-				87BCBA322358E135000BCF46 /* TipSeeManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/TipSee/Base.lproj/Main.storyboard
+++ b/Example/TipSee/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9Hz-Ch-Pc8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="9Hz-Ch-Pc8">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -95,7 +95,7 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                 <inset key="contentEdgeInsets" minX="16" minY="16" maxX="16" maxY="16"/>
-                                <state key="normal" title="i prefer to have bubble on side, but i don't have enough space there">
+                                <state key="normal" title="I prefer to have my tip bubble on the side, but there's not enough space there.">
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                             </button>

--- a/Example/TipSee/ViewController.swift
+++ b/Example/TipSee/ViewController.swift
@@ -99,15 +99,23 @@ class ViewController: UIViewController {
 				
         self.tips = TipSeeManager(on: self.view.window!,with: defaultTipOption)
        
-		tips!.add(new: self.pugImage, texts: ["We can show interactive hints on top of the views or where ever we want but finding the best place to put the bubble (or custom view) is based on the TipSee's decision. it will find best place to show the hint by considering the available space and the content size, smartly",
-		"We can show interactive hints on top of the 's decision. it will find best place to show the hint by considering the available space and the content size, smartly"
-			,"We can show interactive hints on top of the views or "], with: pugLoveConfig) { previousButton, nextButton in
-				nextButton.imageView?.contentMode = .scaleAspectFit
-				previousButton.imageView?.contentMode = .scaleAspectFit
-				nextButton.setImage(#imageLiteral(resourceName: "right-arrow.pdf"), for: .normal)
-				previousButton.setImage(#imageLiteral(resourceName: "left-arrow.pdf"), for: .normal)
-				previousButton.tintColor = .white
-				nextButton.tintColor = .white
+		tips!.add(
+			new: self.pugImage,
+			texts: [
+				"We can show interactive tips on top of views or anything else conforming to `TipTarget`.",
+				"The positioning of the tip bubble (or custom view) is automatically calculated by TipSee for you.",
+				"This decision is based on the size of the tip and the available space around it.",
+				"Alternatively, the tip position can be explicity set for precise control."
+			],
+			with: pugLoveConfig)
+		{
+			previousButton, nextButton in
+			nextButton.imageView?.contentMode = .scaleAspectFit
+			previousButton.imageView?.contentMode = .scaleAspectFit
+			nextButton.setImage(#imageLiteral(resourceName: "right-arrow.pdf"), for: .normal)
+			previousButton.setImage(#imageLiteral(resourceName: "left-arrow.pdf"), for: .normal)
+			previousButton.tintColor = .white
+			nextButton.tintColor = .white
 		}
 		
         tips!.add(new: self.pugImage, text: "Best dog ever <3 <3 ^_^ ^_^", with: pugDescriptionConfig.with{$0.position = .right})
@@ -151,18 +159,24 @@ class ViewController: UIViewController {
 			}
 		})
         
-        tips!.add(new: self.noConstraintsButton,text: "Hi!",with:transformed.with{$0.backgroundColor = .red})
+        tips!.add(new: self.noConstraintsButton,text: "Hi!", with:transformed.with{ $0.backgroundColor = .red })
 		
-		tips!.add(new: SimpleTipTarget(on:  CGRect(x: UIScreen.main.bounds.midX - 50, y: UIScreen.main.bounds.midY - 50, width: 100, height: 100), cornerRadius: 50),text:"no view just shows a tip on this bounds",with:transformed.with{$0.backgroundColor = .red})
+		tips!.add(
+			new: SimpleTipTarget(on:  CGRect(x: UIScreen.main.bounds.midX - 50, y: UIScreen.main.bounds.midY - 50, width: 100, height: 100),cornerRadius: 50),
+			text: "Tip with no target view, just an arbitrary fixed position", with: transformed.with{$0.backgroundColor = .red})
 
-		tips!.add(new: self.bigBottomButton,text: "We can show interactive hints on top of the views or where ever we want but finding the best place to put the bubble (or custom view) is based on the TipSee's decision. it will find best place to show the hint by considering the available space and the content size, smartly",with: transformed.with{
-			$0.onTargetAreaTap = {[weak self]_ in
-				guard let degree = self?.rotationDegree else {return}
- 				self?.rotationDegree = (degree * -1)
+		tips!.add(
+			new: self.bigBottomButton,
+			text: "A long piece of tip text which needs to span over multiple lines. This tip text will only fit if placed above the target area. This placement is provided for us by TipSee.",
+			with: transformed.with {
+				$0.onTargetAreaTap = { [weak self]_ in
+					guard let degree = self?.rotationDegree else {return}
+					self?.rotationDegree = (degree * -1)
+				}
+				$0.backgroundColor = UIColor.black
+				$0.finishOnTargetAreaTap = true
 			}
-			$0.backgroundColor = UIColor.black
-			$0.dismissOnTargetAreaTap = true
-		})
+		)
 
         tips!.onBubbleTap = {[unowned tips] _ in
 			tips?.next()

--- a/TipSee.podspec
+++ b/TipSee.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.version          = '1.4.1'
+  s.version          = '1.5.0'
   s.name             = 'TipSee'
   s.module_name      = 'TipSee'
   s.summary          = 'shows tool beautiful tip or custom views on or alongside the other views.'

--- a/TipSee/Classes/NSAttributedString+Size.swift
+++ b/TipSee/Classes/NSAttributedString+Size.swift
@@ -16,6 +16,6 @@ extension NSAttributedString {
 		let rect = self.boundingRect(with: CGSize(width: widthConstraint, height: heightConstraint),
 									 options: [.usesLineFragmentOrigin, .usesFontLeading],
 									 context: nil)
-        return ceil(rect.size.width + 10)
+        return ceil(rect.size.width)
 	}
 }

--- a/TipSee/Classes/TipOption.swift
+++ b/TipSee/Classes/TipOption.swift
@@ -18,10 +18,10 @@ extension TipSee {
 		case keepTargetAreaCornerRadius
 		
 		/// sets constant radius for all
-		case constantRadius(radius : CGFloat)
+		case constantRadius(radius: CGFloat)
 		
 		/// sets a constant default value or uses the target view layer corner radius if it is greater that the default value
-		case defaultOrGreater(default : CGFloat)
+		case defaultOrGreater(default: CGFloat)
 		
 		/// no corner rradius
 		case none
@@ -32,44 +32,60 @@ extension TipSee {
 		public struct Bubble: TipSeeConfiguration {
 			
 			/// bubble's background color
-			public  var backgroundColor: UIColor
+			public var backgroundColor: UIColor
 			
 			/// preferred position for the bubble
-			public  var position: BubblePosition?
+			public var position: BubblePosition?
 			
 			/// text's font
-			public  var font: UIFont
+			public var font: UIFont
 			
 			/// text's color
-			public  var foregroundColor: UIColor
+			public var foregroundColor: UIColor
 			
 			/// text's alignment
-			public  var textAlignments: NSTextAlignment
+			public var textAlignments: NSTextAlignment
 			
 			/// bubble's appearance animation (bounce + fade-in)
-			public  var hasAppearAnimation: Bool
+			public var hasAppearAnimation: Bool
 			
 			/// distance between the bubble and the target view
-			public  var padding: UIEdgeInsets = .zero
+			public var padding: UIEdgeInsets = .zero
 			
-			/// whole tip(dim and bubble) should be dismiss when user is touched on the target area
-			public  var dismissOnTargetAreaTap: Bool
+			/// Whole tip (dimming and bubble) should be dismissed when user taps on the target area.
+			public var finishOnTargetAreaTap: Bool
 			
-			/// default is false, it true, touches on target area will be passed throught
-			public var isTargetAreaUserinteractionEnabled: Bool
+			/// default is false. It true, touches on target area will be passed through
+			public var shouldPassTouchesThroughTargetArea: Bool
 			
 			/// will execute when user taps on target area
-			public var onTargetAreaTap : TapGesture?
+			public var onTargetAreaTap: TapGesture?
 			
 			/// each tip could has a different dim color
-			public var changeDimColor : UIColor?
-			
+			public var changeDimColor: UIColor?
+
+			/// Whole tip (dimming and bubble) should be dismissed when user taps on the bubble.
+			public var finishOnBubbleTap: Bool
+
 			/// will execute when user taps on the bubble
-			public var onBubbleTap : TapGesture?
+			public var onBubbleTap: TapGesture?
+
 			public static func `default`()->TipSee.Options.Bubble {
-				return Options.Bubble(backgroundColor: .red, position: nil, font: UIFont.boldSystemFont(ofSize: 15), foregroundColor: UIColor.white, textAlignments: .center, hasAppearAnimation: true, padding: .init(top: 16, left: 16, bottom: 16, right: 16), dismissOnTargetAreaTap: false, isTargetAreaUserinteractionEnabled: false,onTargetAreaTap: nil,changeDimColor : nil,onBubbleTap: nil)
+				return Options.Bubble(
+					backgroundColor: .red,
+					position: nil,
+					font: UIFont.boldSystemFont(ofSize: 15),
+					foregroundColor: UIColor.white,
+					textAlignments: .center,
+					hasAppearAnimation: true,
+					padding: .init(top: 16, left: 16, bottom: 16, right: 16),
+					finishOnTargetAreaTap: false,
+					shouldPassTouchesThroughTargetArea: false,
+					onTargetAreaTap: nil,
+					changeDimColor: nil,
+					finishOnBubbleTap: false,
+					onBubbleTap: nil)
 			}
-			
 		}
 		
 		/// buble's options, bubbles will get the default if nothings set
@@ -96,16 +112,24 @@ extension TipSee {
 		/// indicates bubble's margin
 		public var safeAreaInsets: UIEdgeInsets
 		
-		/// if false, the dimTap Callback will not call. some times we need to let users to interact with the views behinde the dim
-		public var absorbDimTouch : Bool
-		
-		/// if true, dim will fade after one second, combine this with absorbDimTouch if you want
-		public var dimFading : Bool
-		
-		/// how long should be taken for the hole to move to the next taeget, default is 0.2s
+		/// if true, dim will fade after one second
+		public var dimFading: Bool
+
+		/// default is false. It true, touches on the dimmed area will be passed through
+		public var shouldPassTouchesThroughDimmingArea: Bool
+
 		public var holePositionChangeDuration: TimeInterval
 		public static func `default`()->TipSee.Options {
-			return Options(bubbles: Options.Bubble.default(), dimColor: UIColor.black.withAlphaComponent(0.7), bubbleLiveDuration: .forever, defaultBubblePosition: .left, holeRadius: .defaultOrGreater(default: 8), safeAreaInsets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16),absorbDimTouch: true,dimFading: true, holePositionChangeDuration: 0.2)
+			return Options(
+				bubbles: Options.Bubble.default(),
+				dimColor: UIColor.black.withAlphaComponent(0.7),
+				bubbleLiveDuration: .forever,
+				defaultBubblePosition: .left,
+				holeRadius: .defaultOrGreater(default: 8),
+				safeAreaInsets: UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16),
+				dimFading: true,
+				shouldPassTouchesThroughDimmingArea: false,
+				holePositionChangeDuration: 0.5)
 		}
 	}
 }

--- a/TipSee/Classes/TipSee+AttributedText.swift
+++ b/TipSee/Classes/TipSee+AttributedText.swift
@@ -35,11 +35,11 @@ extension TipSee {
 	) -> UILabel
 	{
 		let label = UILabel()
+		label.attributedText = text
 		label.textAlignment = .center
 		label.lineBreakMode = .byWordWrapping
 		label.numberOfLines = 0
 		label.font = itemOptions?.font ?? options.bubbles.font
-		label.attributedText = text
 		label.sizeToFit()
 		label.textColor = itemOptions?.foregroundColor ?? options.bubbles.foregroundColor
 		return label

--- a/TipSee/Classes/TipSeeManager.swift
+++ b/TipSee/Classes/TipSeeManager.swift
@@ -6,20 +6,25 @@
 //
 
 public final class TipSeeManager {
-    public private(set) var pointer : TipSee
-    public internal(set) var tips : [TipSee.TipItem]
-    public private(set) var latestTip : TipSee.TipItem?
+    public private(set) var pointer: TipSee
+    public internal(set) var tips: [TipSee.TipItem]
+    public private(set) var latestTip: TipSee.TipItem?
     public var onBubbleTap: ((TipSee.TipItem?) -> Void)? {
-        didSet{
+        didSet {
             pointer.onBubbleTap = self.onBubbleTap
         }
     }
-    public var onDimTap : ((TipSee.TipItem?) -> Void)? {
-        didSet{
+    public var onDimTap: ((TipSee.TipItem?) -> Void)? {
+        didSet {
             pointer.onDimTap = self.onDimTap
         }
     }
-    public private(set) var currentIndex : Int? {
+	public var onFinished: (() -> Void)? {
+		didSet {
+			pointer.onFinished = self.onFinished
+		}
+	}
+    public private(set) var currentIndex: Int? {
         didSet {
             guard let index = currentIndex else {
                 self.pointer.finish()
@@ -67,7 +72,9 @@ public final class TipSeeManager {
         let next = currentIndex+1
         if next < tips.count {
             self.currentIndex = next
-        }
+		} else {
+			finish()
+		}
     }
     
     // shows the previous tip
@@ -88,7 +95,12 @@ public final class TipSeeManager {
 
 extension TipSeeManager {
 	
-	public func add(new view: TipTarget, texts strings: [String], with bubbleOption: TipSee.Options.Bubble?, buttonsConfigs: ((_ previousButton :UIButton, _ nextButton: UIButton)->Void)) {
+	public func add(
+		new view: TipTarget,
+		texts strings: [String],
+		with bubbleOption: TipSee.Options.Bubble?,
+		buttonsConfigs: ((_ previousButton: UIButton, _ nextButton: UIButton) -> Void))
+	{
 		let buttonsHeight : CGFloat = 30
 		let font = bubbleOption?.font ?? pointer.options.bubbles.font
 		var containerHeight  : CGFloat = 40
@@ -183,6 +195,5 @@ extension TipSeeManager {
 		frame.origin.x = frame.size.width * CGFloat(page)
 		frame.origin.y = 0
 		scrollView.scrollRectToVisible(frame, animated: true)
-		
 	}
 }


### PR DESCRIPTION
**New:**
  * Added `onFinished` closure to `TipSeeManager` - this is useful if you want to perform an action(s) on completion of a sequence of tips.
  * Calling `next` will now finish a tip sequence if there are no more tips to display. Previously this did nothing. This has the added advantage of being able to call `next` (wherever you are in a sequence) and have a more expected outcome.
  * Added new bubble options, `finishOnBubbleTap` - The provides an easy way to have the tip dismissed without needing to call `finish` within an on tap closure.
**Breaking changes:**
  * `dismissOnTargetAreaTap` -> `finishOnTargetAreaTap` - this better reflects what happens when a target is tapped.
  * `isTargetAreaUserinteractionEnabled` -> `shouldPassTouchesThroughTargetArea` - better clarifies the behaviour when setting this flag.
  * `absorbDimTouch` -> `shouldPassTouchesThroughDimmingArea` - better clarifies the behaviour when setting this flag.

**Fixes:**
  * Fixed issue where (when configured) touches weren't correctly being passed through the target area to underlying views.
  * Fixed incorrectly calculated attributed text label size.
  * Removed `+10` hack from attributed text width calculation - this is now not required.
  * Minor formatting clean-ups.

**Example:**
  * Reworded the multi-tip text to more clearly summarise TipSee functionality and the auto positioning of tips.
  * Fixed typos in example tip text.