### PR TITLE
Fixed issue when using multiple instances of `TipSee`

### DIFF
--- a/Sources/TipSee/TipSee.swift
+++ b/Sources/TipSee/TipSee.swift
@@ -179,7 +179,7 @@ public class TipSee: UIView, TipSeeManagerProtocol {
 	
 	@objc
 	private func tapBubble(_ sender: UITapGestureRecognizer) {
-		guard let item = self.views.first(where:{item in item.ID == sender.identifier} )else {
+		guard let item = self.views.first(where: { item in item.ID == sender.identifier }) else {
 			assertionFailure("Here we have to have that bubble(tip) but we can not find it")
 			return
 		}
@@ -506,14 +506,22 @@ extension TipSee {
 	}
 }
 
-private var ExteraIDForTapGesture: String = ""
 private extension UITapGestureRecognizer {
+
+	private struct AssociatedKeys {
+		static var identifier = "identifier"
+	}
+
 	var identifier: String {
-		set {
-			ExteraIDForTapGesture = newValue
-		}
 		get {
-			return ExteraIDForTapGesture
+			return (objc_getAssociatedObject(self, &AssociatedKeys.identifier) as? String) ?? ""
+		} set {
+			objc_setAssociatedObject(
+				self,
+				&AssociatedKeys.identifier,
+				newValue,
+				.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+			)
 		}
 	}
 }

--- a/TipSee.podspec
+++ b/TipSee.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.version          = '1.6.0'
+  s.version          = '1.6.1'
   s.name             = 'TipSee'
   s.module_name      = 'TipSee'
   s.summary          = 'A lightweight, highly customizable tip / hint library for Swift'


### PR DESCRIPTION
  * `ExteraIDForTapGesture` was previously shared between `TipSee` instances. This resulted in the bubble tap handling failing due to `UITapGestureRecognizer`s having an incorrect identifier associated with them.
  * Upversioned -> 1.6.1