### PR TITLE
Fixed issue where the `onTargetAreaTap` closure could still be called…

### DIFF
--- a/Sources/TipSee/TipSee.swift
+++ b/Sources/TipSee/TipSee.swift
@@ -53,20 +53,21 @@ public class TipSee: UIView, TipSeeManagerProtocol {
 		return TipItem(ID: UUID().uuidString, pointTo: target, contentView: TipSee.createLabel(for: text, with: bubbleOption, defaultOptions: .default()) as UIView, bubbleOptions: bubbleOption)
 	}
 	
-	private final func clearAllViews(){
+	private final func clearAllViews() {
 		guard  !views.isEmpty else{return}
 		views.forEach { (item) in
 			self.dismiss(item: item)
 		}
 	}
 	
-	private final func store(tip : TipItem,bubble : BubbleView){
+	private final func store(tip : TipItem,bubble : BubbleView) {
 		self.latestTip = tip
 		self.views.append(tip)
 		self.bubbles.append(bubble)
 	}
 	
-	private final func deStore(index : Int){
+	private final func deStore(index : Int) {
+		self.latestTip = nil
 		if self.bubbles.count > index {
 			self.bubbles.remove(at: index)
 		}

--- a/TipSee.podspec
+++ b/TipSee.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.version          = '1.6.1'
+  s.version          = '1.6.2'
   s.name             = 'TipSee'
   s.module_name      = 'TipSee'
   s.summary          = 'A lightweight, highly customizable tip / hint library for Swift'


### PR DESCRIPTION
… in response to the user tapping on a tip which has already been dismissed. This was due to the `latestTip` not getting cleared down after being dismissed.