### PR TITLE
Fixed issue where tips could be cycled prematurely

### DIFF
--- a/TipSee.podspec
+++ b/TipSee.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.version          = '1.6.2'
+  s.version          = '1.6.3'
   s.name             = 'TipSee'
   s.module_name      = 'TipSee'
   s.summary          = 'A lightweight, highly customizable tip / hint library for Swift'


### PR DESCRIPTION
* If tapping on a target area or the dimmed background (with pass touches through option set) mid way through a tip animation sequence it was possible to interrupt the sequence. Depending on the setup, the interruption could lead to the next tip being cycled to before the previous animation sequence completed. This could lead to tips being activated prematurely and therefore showing on an incorrect screen or screen layout.
* Minor code formatting consistency clean-ups