### PR TITLE
Dismiss on dimmed area tap

### DIFF
--- a/Example/TipSee/ViewController.swift
+++ b/Example/TipSee/ViewController.swift
@@ -174,7 +174,7 @@ class ViewController: UIViewController {
 					self?.rotationDegree = (degree * -1)
 				}
 				$0.backgroundColor = UIColor.black
-				$0.finishOnTargetAreaTap = true
+				$0.shouldFinishOnTargetAreaTap = true
 			}
 		)
 

--- a/README.md
+++ b/README.md
@@ -37,81 +37,84 @@ If a both a base and per tip configuration is set, then the per tip configuratio
 ```swift
 public struct Options: TipSeeConfiguration {
 
-    /// buble's options, bubbles will get the default if nothings set
-    public var bubbles: Bubble
+  /// buble's options, bubbles will get the default if nothings set
+  public var bubbles: Bubble
 
-    /// default dim's color, each bubble could changes this color(optionaly) by setting the bubble.dimBackgroundColor
-    public var dimColor: UIColor
+  /// default dim's color, each bubble could changes this color(optionaly) by setting the bubble.dimBackgroundColor
+  public var dimColor: UIColor
 
-    /// bubble's life cycle.
-    /// forEver : bubbles will be visible and needs to be remove manualy by caliing dismiss(item), you can show multiple bubbles same time
-    /// untilNext: everytime show() function is called, previous bubble(if exists) will remove and new one will present
-    public var bubbleLiveDuration: BubbleLiveDuration
+  /// bubble's life cycle.
+  /// forEver : bubbles will be visible and needs to be remove manualy by caliing dismiss(item), you can show multiple bubbles same time
+  /// untilNext: everytime show() function is called, previous bubble(if exists) will remove and new one will present
+  public var bubbleLiveDuration: BubbleLiveDuration
 
-    /// indicates the default bubble's position, each bubble can has specific position by setting bubble.position
-    public var defaultBubblePosition: BubblePosition
+  /// indicates the default bubble's position, each bubble can has specific position by setting bubble.position
+  public var defaultBubblePosition: BubblePosition
 
-    /// specifies the hole's(Target Area) radius
-    /// keepTargetAreaCornerRadius : uses target view layer corner radius
-    /// constantRadius(radius) : sets constant radius for all
-    /// defaultOrGreater(default) : sets a constant default value or uses the target view layer corner radius if it is greater that the default value
-    /// none : no corner rradius
-    public var holeRadius: HoleRadius
+  /// specifies the hole's(Target Area) radius
+  /// keepTargetAreaCornerRadius : uses target view layer corner radius
+  /// constantRadius(radius) : sets constant radius for all
+  /// defaultOrGreater(default) : sets a constant default value or uses the target view layer corner radius if it is greater that the default value
+  /// none : no corner rradius
+  public var holeRadius: HoleRadius
 
-    /// indicates bubble's margin
-    public var safeAreaInsets: UIEdgeInsets
+  /// indicates bubble's margin
+  public var safeAreaInsets: UIEdgeInsets
 
-    /// if true, dim will fade after one second
-    public var dimFading: Bool
+  /// if true, dim will fade after one second
+  public var dimFading: Bool
 
-    /// default is false. It true, touches on the dimmed area will be passed through
-    public var shouldPassTouchesThroughDimmingArea: Bool
+  /// default is false. It true, touches on the dimmed area will be passed through
+  public var shouldPassTouchesThroughDimmingArea: Bool
 
-    public var holePositionChangeDuration: TimeInterval
+  public var holePositionChangeDuration: TimeInterval
 }
 ```
 **Bubble Options**
 ```swift 
 public struct Bubble: TipSeeConfiguration {
   
-    /// bubble's background color
-    public var backgroundColor: UIColor
+  /// bubble's background color
+  public var backgroundColor: UIColor
 
-    /// preferred position for the bubble
-    public var position: BubblePosition?
+  /// preferred position for the bubble
+  public var position: BubblePosition?
 
-    /// text's font
-    public var font: UIFont
+  /// text's font
+  public var font: UIFont
 
-    /// text's color
-    public var foregroundColor: UIColor
+  /// text's color
+  public var foregroundColor: UIColor
 
-    /// text's alignment
-    public var textAlignments: NSTextAlignment
+  /// text's alignment
+  public var textAlignments: NSTextAlignment
 
-    /// bubble's appearance animation (bounce + fade-in)
-    public var hasAppearAnimation: Bool
+  /// bubble's appearance animation (bounce + fade-in)
+  public var hasAppearAnimation: Bool
 
-    /// distance between the bubble and the target view
-    public var padding: UIEdgeInsets = .zero
+  /// distance between the bubble and the target view
+  public var padding: UIEdgeInsets = .zero
 
-    /// Whole tip (dimming and bubble) should be dismissed when user taps on the target area.
-    public var finishOnTargetAreaTap: Bool
+  /// default is false. It true, touches on target area will be passed through
+  public var shouldPassTouchesThroughTargetArea: Bool
 
-    /// default is false. It true, touches on target area will be passed through
-    public var shouldPassTouchesThroughTargetArea: Bool
+  /// will execute when user taps on target area
+  public var onTargetAreaTap: TapGesture?
 
-    /// will execute when user taps on target area
-    public var onTargetAreaTap: TapGesture?
+  /// each tip could has a different dim color
+  public var changeDimColor: UIColor?
 
-    /// each tip could has a different dim color
-    public var changeDimColor: UIColor?
+  /// Whole tip (dimming and bubble) should be dismissed when user taps on the target area.
+  public var shouldFinishOnTargetAreaTap: Bool
 
-    /// Whole tip (dimming and bubble) should be dismissed when user taps on the bubble.
-    public var finishOnBubbleTap: Bool
+  /// Whole tip (dimming and bubble) should be dismissed when user taps on the surronding dimmed area.
+  public var shouldFinishOnDimmedAreaTap: Bool
 
-    /// will execute when user taps on the bubble
-    public var onBubbleTap: TapGesture?
+  /// Whole tip (dimming and bubble) should be dismissed when user taps on the bubble.
+  public var shouldFinishOnBubbleTap: Bool
+
+  /// will execute when user taps on the bubble
+  public var onBubbleTap: TapGesture?
 }
 ```
 

--- a/Sources/TipSee/TipOption.swift
+++ b/Sources/TipSee/TipOption.swift
@@ -53,10 +53,7 @@ extension TipSee {
 			
 			/// distance between the bubble and the target view
 			public var padding: UIEdgeInsets = .zero
-			
-			/// Whole tip (dimming and bubble) should be dismissed when user taps on the target area.
-			public var finishOnTargetAreaTap: Bool
-			
+
 			/// default is false. It true, touches on target area will be passed through
 			public var shouldPassTouchesThroughTargetArea: Bool
 			
@@ -66,8 +63,14 @@ extension TipSee {
 			/// each tip could has a different dim color
 			public var changeDimColor: UIColor?
 
+			/// Whole tip (dimming and bubble) should be dismissed when user taps on the target area.
+			public var shouldFinishOnTargetAreaTap: Bool
+
+			/// Whole tip (dimming and bubble) should be dismissed when user taps on the surronding dimmed area.
+			public var shouldFinishOnDimmedAreaTap: Bool
+
 			/// Whole tip (dimming and bubble) should be dismissed when user taps on the bubble.
-			public var finishOnBubbleTap: Bool
+			public var shouldFinishOnBubbleTap: Bool
 
 			/// will execute when user taps on the bubble
 			public var onBubbleTap: TapGesture?
@@ -81,11 +84,12 @@ extension TipSee {
 					textAlignments: .center,
 					hasAppearAnimation: true,
 					padding: .init(top: 16, left: 16, bottom: 16, right: 16),
-					finishOnTargetAreaTap: false,
 					shouldPassTouchesThroughTargetArea: false,
 					onTargetAreaTap: nil,
 					changeDimColor: nil,
-					finishOnBubbleTap: false,
+					shouldFinishOnTargetAreaTap: false,
+					shouldFinishOnDimmedAreaTap: false,
+					shouldFinishOnBubbleTap: false,
 					onBubbleTap: nil)
 			}
 		}

--- a/Sources/TipSee/TipSee.swift
+++ b/Sources/TipSee/TipSee.swift
@@ -197,7 +197,7 @@ public class TipSee: UIView, TipSeeManagerProtocol {
 			onBubbleTap?(item)
 		}
 		let option = item.bubbleOptions ?? self.options.bubbles
-		if option.finishOnBubbleTap {
+		if option.shouldFinishOnBubbleTap {
 			self.finish()
 		}
 	}
@@ -503,10 +503,9 @@ extension TipSee {
 
 		if isInTargetArea {
 			option.onTargetAreaTap?(latestTip)
-			if option.finishOnTargetAreaTap {
+			if option.shouldFinishOnTargetAreaTap {
 				self.finish()
 			}
-
 			if option.shouldPassTouchesThroughTargetArea == false {
 				// Consume the touch
 				return true
@@ -522,6 +521,9 @@ extension TipSee {
 
 		let isInDimmingArea = frame.contains(point)
 		if isInDimmingArea {
+			if option.shouldFinishOnDimmedAreaTap {
+				self.finish()
+			}
 			if options.shouldPassTouchesThroughDimmingArea == false {
 				// Consume the touch
 				return true

--- a/TipSee.podspec
+++ b/TipSee.podspec
@@ -7,7 +7,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.version          = '1.6.3'
+  s.version          = '1.6.4'
   s.name             = 'TipSee'
   s.module_name      = 'TipSee'
   s.summary          = 'A lightweight, highly customizable tip / hint library for Swift'


### PR DESCRIPTION
* Bubbles can now be configured to be dismissed when the user taps on the surrounding (dimmed) area. Useful for when wanting to show light touch tips which dismiss when the user starts interacting with the screen.
* `finishOnTargetAreaTap` -> `shouldFinishOnTargetAreaTap` & `finishOnBubbleTap` -> `shouldFinishOnBubbleTap` for naming consistency.
* Updated `README.md` to reflect changes.
* Version bumped `podspec`